### PR TITLE
SUGGESTION: Add Sitegeist.MagicWand

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ This list provides resources and information around Neos CMS and its community.
 
 **Install:** `composer require flowpack/listable`
 
+#### [Sitegeist.Magicwand](link/to/package/on/github)
+
+> Automatic local reproduction of deployed Neos CMS installations
+
+**Install:** `composer require sitegeist/magicwand`
+
+**Author(s):** [Martin Ficzel](https://github.com/mficzel), [Wilhelm Behncke](https://github.com/grebaldi)
+
+**Sponsor(s):** [sitegeist neos solutions GmbH](https://sitegeist.de/)
+
 ## License
 
 [![CC0](http://mirrors.creativecommons.org/presskit/buttons/88x31/svg/cc-zero.svg)](https://creativecommons.org/publicdomain/zero/1.0/)


### PR DESCRIPTION
Sitegeist.MagicWand is a tool that helps to clone remote Neos CMS installation onto your local machine, restoring the exact state of Database and Persistent File Storage of that installation.

It also helps to create snapshots of your current local state, that can be restored at a later point - which is great for testing migrations.